### PR TITLE
feat: Ignore temporary files and macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Project
+tmp/
+.DS_Store


### PR DESCRIPTION
Add `.gitignore` entries to exclude temporary files and macOS metadata from the repository. This ensures that the repository remains clean and focuses on essential project files.