### PR TITLE
Disable release workflow triggered by push to main

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [closed]
 
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
 
 # env:
 #   ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
The workflow will now only run on closed pull requests to prevent accidental releases. This avoids the risk of releasing unintended changes directly to the `main` branch.