### PR TITLE
Fix: Remove unnecessary release notes generation

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -45,7 +45,6 @@ jobs:
     #       token: ${{secrets.WORKFLOW_TOKEN}}
     #       generate_release_notes: true
 
-
     outputs:
       # current_version: ${{ steps.generate-version.outputs.CURRENT_VERSION }}
       new_version: ${{ steps.generate-version.outputs.version }}


### PR DESCRIPTION
The workflow was configured to generate release notes, but this functionality is not currently needed. This commit removes the unnecessary `generate_release_notes` flag from the `create-release` step.